### PR TITLE
feat(payment-debt): add endpoint to retrieve payments by debt ID

### DIFF
--- a/src/main/java/com/lian/marketing/paymentmicroservice/application/handler/PaymentHandler.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/application/handler/PaymentHandler.java
@@ -3,9 +3,13 @@ package com.lian.marketing.paymentmicroservice.application.handler;
 import com.lian.marketing.paymentmicroservice.application.dto.request.CreatePaymentRequest;
 import com.lian.marketing.paymentmicroservice.application.mapper.IPaymentMapper;
 import com.lian.marketing.paymentmicroservice.domain.api.IPaymentServicePort;
+import com.lian.marketing.paymentmicroservice.domain.model.Payment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @Transactional
@@ -21,5 +25,9 @@ public class PaymentHandler {
 
     public void createPaymentDebt(CreatePaymentRequest request) {
         paymentServicePort.createPaymentDebt(paymentMapper.toModelFromRequest(request));
+    }
+
+    public List<Payment> findDebtPaymentsByDebtId(UUID debtId) {
+        return paymentServicePort.findDebtPaymentsByDebtId(debtId);
     }
 }

--- a/src/main/java/com/lian/marketing/paymentmicroservice/domain/api/IDebtServicePort.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/domain/api/IDebtServicePort.java
@@ -12,4 +12,5 @@ public interface IDebtServicePort {
     boolean existsAndActiveByDebtAndClientId(UUID debtId, UUID clientId);
     void updateTotalRemainingAmount(BigDecimal remainingAmount, UUID debtId);
     ContentPage<ActiveDebt> findActiveDebts(int page, int size, boolean dateAsc);
+    void existsActiveDebtById(UUID id);
 }

--- a/src/main/java/com/lian/marketing/paymentmicroservice/domain/api/IPaymentServicePort.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/domain/api/IPaymentServicePort.java
@@ -2,7 +2,11 @@ package com.lian.marketing.paymentmicroservice.domain.api;
 
 import com.lian.marketing.paymentmicroservice.domain.model.Payment;
 
+import java.util.List;
+import java.util.UUID;
+
 public interface IPaymentServicePort {
     void createPaymentFromTransaction(Payment payment);
     void createPaymentDebt(Payment payment);
+    List<Payment> findDebtPaymentsByDebtId(UUID debtId);
 }

--- a/src/main/java/com/lian/marketing/paymentmicroservice/domain/api/usecase/DebtUseCase.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/domain/api/usecase/DebtUseCase.java
@@ -71,6 +71,13 @@ public class DebtUseCase implements IDebtServicePort {
         return mapToActiveDebt(debts);
     }
 
+    @Override
+    public void existsActiveDebtById(UUID id) {
+        if(!debtPersistencePort.existsActiveDebtById(id)){
+            throw new DebtDoNotExists(ExceptionConstants.DEBT_DO_NOT_EXISTS);
+        }
+    }
+
     private String getClientNameById(UUID clientId){
         return debtPersistencePort.getClientNameByIdFromTransaction(clientId);
     }

--- a/src/main/java/com/lian/marketing/paymentmicroservice/domain/api/usecase/PaymentUseCase.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/domain/api/usecase/PaymentUseCase.java
@@ -10,6 +10,8 @@ import com.lian.marketing.paymentmicroservice.domain.spi.IPaymentPersistencePort
 import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 public class PaymentUseCase implements IPaymentServicePort {
@@ -32,5 +34,11 @@ public class PaymentUseCase implements IPaymentServicePort {
         }
         paymentPersistencePort.savePayment(payment);
         debtServicePort.updateTotalRemainingAmount(BigDecimal.valueOf(payment.getAmount()), payment.getDebtId());
+    }
+
+    @Override
+    public List<Payment> findDebtPaymentsByDebtId(UUID debtId) {
+        debtServicePort.existsActiveDebtById(debtId);
+        return paymentPersistencePort.findAllByDebtId(debtId);
     }
 }

--- a/src/main/java/com/lian/marketing/paymentmicroservice/domain/spi/IDebtPersistencePort.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/domain/spi/IDebtPersistencePort.java
@@ -13,4 +13,5 @@ public interface IDebtPersistencePort {
     Optional<Debt> findById(UUID debtId);
     ContentPage<Debt> findActiveDebts(int page, int size, boolean dateAsc);
     String getClientNameByIdFromTransaction(UUID clientId);
+    boolean existsActiveDebtById(UUID id);
 }

--- a/src/main/java/com/lian/marketing/paymentmicroservice/domain/spi/IPaymentPersistencePort.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/domain/spi/IPaymentPersistencePort.java
@@ -2,9 +2,11 @@ package com.lian.marketing.paymentmicroservice.domain.spi;
 
 import com.lian.marketing.paymentmicroservice.domain.model.Payment;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface IPaymentPersistencePort {
     void savePayment(Payment payment);
     boolean clientExists(UUID clientId);
+    List<Payment> findAllByDebtId(UUID debtId);
 }

--- a/src/main/java/com/lian/marketing/paymentmicroservice/infrastructure/driven/jpa/postgres/adapter/DebtAdapter.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/infrastructure/driven/jpa/postgres/adapter/DebtAdapter.java
@@ -74,4 +74,9 @@ public class DebtAdapter implements IDebtPersistencePort {
                 .bodyToMono(String.class)
                 .block();
     }
+
+    @Override
+    public boolean existsActiveDebtById(UUID id) {
+        return debtRepository.existsActiveDebtById(id);
+    }
 }

--- a/src/main/java/com/lian/marketing/paymentmicroservice/infrastructure/driven/jpa/postgres/adapter/PaymentAdapter.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/infrastructure/driven/jpa/postgres/adapter/PaymentAdapter.java
@@ -7,6 +7,7 @@ import com.lian.marketing.paymentmicroservice.infrastructure.driven.jpa.postgres
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.List;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -29,5 +30,13 @@ public class PaymentAdapter implements IPaymentPersistencePort {
                 .bodyToMono(Boolean.class)
                 .blockOptional()
                 .orElse(false);
+    }
+
+    @Override
+    public List<Payment> findAllByDebtId(UUID debtId) {
+        return paymentRepository.findByDebtId(debtId)
+          .stream()
+          .map(paymentEntityMapper::toModelFromEntity)
+          .toList();
     }
 }

--- a/src/main/java/com/lian/marketing/paymentmicroservice/infrastructure/driven/jpa/postgres/mapper/IPaymentEntityMapper.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/infrastructure/driven/jpa/postgres/mapper/IPaymentEntityMapper.java
@@ -7,4 +7,5 @@ import org.mapstruct.Mapper;
 @Mapper(componentModel = "spring")
 public interface IPaymentEntityMapper {
     PaymentEntity toEntityFromModel(Payment payment);
+    Payment toModelFromEntity(PaymentEntity paymentEntity);
 }

--- a/src/main/java/com/lian/marketing/paymentmicroservice/infrastructure/driven/jpa/postgres/repository/IDebtRepository.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/infrastructure/driven/jpa/postgres/repository/IDebtRepository.java
@@ -20,4 +20,7 @@ public interface IDebtRepository extends JpaRepository<DebtEntity, UUID> {
 
     @Query(value = "SELECT * FROM public.Debt WHERE status = 'PENDING'", nativeQuery = true)
     Page<DebtEntity> findActiveDebts(Pageable pageable);
+
+    @Query(value = "SELECT EXISTS(SELECT 1 FROM public.Debt WHERE id = :id AND status = 'PENDING')", nativeQuery = true)
+    boolean existsActiveDebtById(UUID id);
 }

--- a/src/main/java/com/lian/marketing/paymentmicroservice/infrastructure/driven/jpa/postgres/repository/IPaymentRepository.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/infrastructure/driven/jpa/postgres/repository/IPaymentRepository.java
@@ -3,7 +3,9 @@ package com.lian.marketing.paymentmicroservice.infrastructure.driven.jpa.postgre
 import com.lian.marketing.paymentmicroservice.infrastructure.driven.jpa.postgres.entity.PaymentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface IPaymentRepository extends JpaRepository<PaymentEntity, UUID> {
+  List<PaymentEntity> findByDebtId(UUID debtId);
 }

--- a/src/main/java/com/lian/marketing/paymentmicroservice/infrastructure/driving/http/controller/PaymentController.java
+++ b/src/main/java/com/lian/marketing/paymentmicroservice/infrastructure/driving/http/controller/PaymentController.java
@@ -2,13 +2,14 @@ package com.lian.marketing.paymentmicroservice.infrastructure.driving.http.contr
 
 import com.lian.marketing.paymentmicroservice.application.dto.request.CreatePaymentRequest;
 import com.lian.marketing.paymentmicroservice.application.handler.PaymentHandler;
+import com.lian.marketing.paymentmicroservice.domain.model.Payment;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/payment")
@@ -27,6 +28,11 @@ public class PaymentController {
     public ResponseEntity<Void> createPaymentDebt(@Valid @RequestBody CreatePaymentRequest request) {
         paymentHandler.createPaymentDebt(request);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/debt/{id}")
+    public ResponseEntity<List<Payment>> findDebtPaymentsByDebtId(@PathVariable UUID id) {
+        return ResponseEntity.ok().body(paymentHandler.findDebtPaymentsByDebtId(id));
     }
 
 }


### PR DESCRIPTION
- Introduced `/debt/{id}` endpoint in `PaymentController` for fetching payments related to a specific debt.
- Added `existsActiveDebtById` validation in `DebtUseCase` to ensure active debt existence.
- Updated service, use case, and persistence layers to support debt payments retrieval.